### PR TITLE
fix: skip setting editor.rangeHighlightBorder

### DIFF
--- a/themes/_pinecone-color-theme.json
+++ b/themes/_pinecone-color-theme.json
@@ -108,7 +108,7 @@
 		"editor.lineHighlightBorder": "$transparent",
 		"editor.linkedEditingBackground": "$surface",
 		"editor.rangeHighlightBackground": "$highlightLow",
-		"editor.rangeHighlightBorder": "$transparent",
+		"editor.rangeHighlightBorder": "",
 		"editor.selectionBackground": "$highlightMed",
 		"editor.selectionForeground": "$text",
 		"editor.selectionHighlightBackground": "$highlightMed",

--- a/themes/rose-pine-color-theme.json
+++ b/themes/rose-pine-color-theme.json
@@ -84,7 +84,6 @@
 		"editor.lineHighlightBorder": "#0000",
 		"editor.linkedEditingBackground": "#1f1d2e",
 		"editor.rangeHighlightBackground": "#6e6a861a",
-		"editor.rangeHighlightBorder": "#0000",
 		"editor.selectionBackground": "#6e6a8633",
 		"editor.selectionForeground": "#e0def4",
 		"editor.selectionHighlightBackground": "#6e6a8633",

--- a/themes/rose-pine-dawn-color-theme.json
+++ b/themes/rose-pine-dawn-color-theme.json
@@ -84,7 +84,6 @@
 		"editor.lineHighlightBorder": "#0000",
 		"editor.linkedEditingBackground": "#fffaf3",
 		"editor.rangeHighlightBackground": "#6e6a860d",
-		"editor.rangeHighlightBorder": "#0000",
 		"editor.selectionBackground": "#6e6a8614",
 		"editor.selectionForeground": "#575279",
 		"editor.selectionHighlightBackground": "#6e6a8614",

--- a/themes/rose-pine-moon-color-theme.json
+++ b/themes/rose-pine-moon-color-theme.json
@@ -84,7 +84,6 @@
 		"editor.lineHighlightBorder": "#0000",
 		"editor.linkedEditingBackground": "#2a273f",
 		"editor.rangeHighlightBackground": "#817c9c14",
-		"editor.rangeHighlightBorder": "#0000",
 		"editor.selectionBackground": "#817c9c26",
 		"editor.selectionForeground": "#e0def4",
 		"editor.selectionHighlightBackground": "#817c9c26",


### PR DESCRIPTION
prevents red line highlight border for rapidAPI search matches