### PR TITLE
Add font style rules for markdown

### DIFF
--- a/themes/_pinecone-color-theme.json
+++ b/themes/_pinecone-color-theme.json
@@ -764,6 +764,24 @@
 			}
 		},
 		{
+			"scope": "markup.heading",
+			"settings": {
+				"fontStyle":"bold"
+			}
+		},
+		{
+			"scope": "markup.bold.markdown",
+			"settings": {
+				"fontStyle":"bold"
+			}
+		},
+		{
+			"scope": "markup.italic.markdown",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
 			"scope": ["meta.diff.range"],
 			"settings": {
 				"foreground": "$iris"

--- a/themes/rose-pine-color-theme.json
+++ b/themes/rose-pine-color-theme.json
@@ -537,24 +537,6 @@
 			}
 		},
 		{
-			"scope": "markup.heading",
-			"settings": {
-				"fontStyle":"bold"
-			}
-		},
-		{
-			"scope": "markup.bold.markdown",
-			"settings": {
-				"fontStyle":"bold"
-			}
-		},
-		{
-			"scope": "markup.italic.markdown",
-			"settings": {
-				"fontStyle": "italic"
-			}
-		},
-		{
 			"scope": ["meta.diff.range"],
 			"settings": {
 				"foreground": "#c4a7e7"

--- a/themes/rose-pine-color-theme.json
+++ b/themes/rose-pine-color-theme.json
@@ -537,6 +537,24 @@
 			}
 		},
 		{
+			"scope": "markup.heading",
+			"settings": {
+				"fontStyle":"bold"
+			}
+		},
+		{
+			"scope": "markup.bold.markdown",
+			"settings": {
+				"fontStyle":"bold"
+			}
+		},
+		{
+			"scope": "markup.italic.markdown",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
 			"scope": ["meta.diff.range"],
 			"settings": {
 				"foreground": "#c4a7e7"


### PR DESCRIPTION
Adding font styles to several textmate scopes in markdown:

- Heading (**bold**)
- Inline bold (**Bold**)
- Inline italic (*italic*)

<img width="1135" alt="image" src="https://user-images.githubusercontent.com/67518483/229891578-f2dfced6-1fb4-44be-af20-b782005aa9d7.png">
