### PR TITLE
Added colouring to "this" keyword

### DIFF
--- a/themes/rose-pine-color-theme.json
+++ b/themes/rose-pine-color-theme.json
@@ -519,7 +519,7 @@
 			}
 		},
 		{
-			"scope": ["keyword"],
+			"scope": ["keyword", "variable.language.this"],
 			"settings": {
 				"foreground": "#31748f"
 			}

--- a/themes/rose-pine-dawn-color-theme.json
+++ b/themes/rose-pine-dawn-color-theme.json
@@ -519,7 +519,7 @@
 			}
 		},
 		{
-			"scope": ["keyword"],
+			"scope": ["keyword", "variable.language.this"],
 			"settings": {
 				"foreground": "#286983"
 			}

--- a/themes/rose-pine-dawn-no-italics-color-theme.json
+++ b/themes/rose-pine-dawn-no-italics-color-theme.json
@@ -519,7 +519,7 @@
 			}
 		},
 		{
-			"scope": ["keyword"],
+			"scope": ["keyword", "variable.language.this"],
 			"settings": {
 				"foreground": "#286983"
 			}

--- a/themes/rose-pine-moon-color-theme.json
+++ b/themes/rose-pine-moon-color-theme.json
@@ -519,7 +519,7 @@
 			}
 		},
 		{
-			"scope": ["keyword"],
+			"scope": ["keyword", "variable.language.this"],
 			"settings": {
 				"foreground": "#3e8fb0"
 			}

--- a/themes/rose-pine-moon-no-italics-color-theme.json
+++ b/themes/rose-pine-moon-no-italics-color-theme.json
@@ -519,7 +519,7 @@
 			}
 		},
 		{
-			"scope": ["keyword"],
+			"scope": ["keyword", "variable.language.this"],
 			"settings": {
 				"foreground": "#3e8fb0"
 			}

--- a/themes/rose-pine-no-italics-color-theme.json
+++ b/themes/rose-pine-no-italics-color-theme.json
@@ -519,7 +519,7 @@
 			}
 		},
 		{
-			"scope": ["keyword"],
+			"scope": ["keyword", "variable.language.this"],
 			"settings": {
 				"foreground": "#31748f"
 			}


### PR DESCRIPTION
Fixing issue #67 

**Rose Pine Moon**
*Before:*
![image](https://github.com/rose-pine/vscode/assets/27804703/3404f89e-6ff3-4c3b-8456-5f96f98ab224)
*After:*
![image](https://github.com/rose-pine/vscode/assets/27804703/da119f1e-d7fb-4c21-b431-fefb9d6f1499)


**Rose Pine**
*Before:*
![image](https://github.com/rose-pine/vscode/assets/27804703/d3c9aec0-c963-4e0d-a861-8fdfc8783b69)
*After:*
![image](https://github.com/rose-pine/vscode/assets/27804703/a9534a4b-2425-4ce4-9dec-b596c71ee41b)


**Rose Pine Dawn**
*Before:*
![image](https://github.com/rose-pine/vscode/assets/27804703/71a9c23e-e9e4-475b-a408-94ac23003f08)
*After:*
![image](https://github.com/rose-pine/vscode/assets/27804703/85ad1cb7-2652-4439-8833-53e249854475)

Let me know if you have any issues with just keeping the same keyword colouring since `this` is a keyword in most OOP languages 😊
