### PR TITLE
Add css overwrite

### DIFF
--- a/icons/rose-pine-icon-theme.json
+++ b/icons/rose-pine-icon-theme.json
@@ -22,7 +22,8 @@
 	"folderExpanded": "_folder-open",
 	"fileExtensions": {
 		"astro": "_file",
-		"bicep": "_file"
+		"bicep": "_file",
+		"css": "_file"
 	},
 	"hidesExplorerArrows": true
 }


### PR DESCRIPTION
Fixes #91

I was able to reproduce the issue.

- In a react project, get tailwindcss, prettier. 
- When you create a css file, it'll use the tailwind icon.


![image](https://github.com/user-attachments/assets/e34aed3b-dbfc-445e-a4be-9ae9a0962436)

I have not tested the changes, but this should be the fix.