### PR TITLE
fix: align Github Copilot chat input field color with input panel

### DIFF
--- a/pinecone.config.js
+++ b/pinecone.config.js
@@ -1,6 +1,25 @@
 import { colorish, defineConfig } from 'pinecone-cli'
 import { roles } from '@rose-pine/palette'
 
+const blend = (foreground, background, alpha) => {
+	const channels = (hex) =>
+		hex
+			.replace('#', '')
+			.match(/.{2}/g)
+			.map((channel) => Number.parseInt(channel, 16))
+
+	const foregroundChannels = channels(foreground)
+	const backgroundChannels = channels(background)
+
+	return `#${foregroundChannels
+		.map((channel, index) =>
+			Math.round(channel * alpha + backgroundChannels[index] * (1 - alpha))
+				.toString(16)
+				.padStart(2, '0')
+		)
+		.join('')}`
+}
+
 const palette = {}
 Object.keys(roles).map((role) => {
 	const currentRole = roles[role]
@@ -40,6 +59,12 @@ Object.keys(roles).map((role) => {
 	}
 })
 
+const inputBackground = {
+	main: blend(roles.overlay.main.hex, roles.surface.main.hex, 0.5),
+	moon: blend(roles.overlay.moon.hex, roles.surface.moon.hex, 0.5),
+	dawn: blend(roles.overlay.dawn.hex, roles.surface.dawn.hex, 0.5),
+}
+
 export default defineConfig({
 	options: {
 		source: './themes/_pinecone-color-theme.json',
@@ -72,6 +97,8 @@ export default defineConfig({
 		onSecondary: palette.base,
 		secondary: palette.iris,
 		secondaryHover: colorish(palette.iris, 0.9),
+
+		inputBackground,
 
 		...palette,
 	},

--- a/themes/_pinecone-color-theme.json
+++ b/themes/_pinecone-color-theme.json
@@ -255,7 +255,7 @@
 		"gitDecoration.submoduleResourceForeground": "$gold",
 		"gitDecoration.untrackedResourceForeground": "$gold",
 		"icon.foreground": "$subtle",
-		"input.background": "$overlay/50",
+		"input.background": "$surface",
 		"input.border": "$highlightMed",
 		"input.foreground": "$text",
 		"input.placeholderForeground": "$subtle",

--- a/themes/_pinecone-color-theme.json
+++ b/themes/_pinecone-color-theme.json
@@ -255,7 +255,7 @@
 		"gitDecoration.submoduleResourceForeground": "$gold",
 		"gitDecoration.untrackedResourceForeground": "$gold",
 		"icon.foreground": "$subtle",
-		"input.background": "$surface",
+		"input.background": "$inputBackground",
 		"input.border": "$highlightMed",
 		"input.foreground": "$text",
 		"input.placeholderForeground": "$subtle",

--- a/themes/rose-pine-color-theme.json
+++ b/themes/rose-pine-color-theme.json
@@ -226,7 +226,7 @@
 		"gitDecoration.submoduleResourceForeground": "#f6c177",
 		"gitDecoration.untrackedResourceForeground": "#f6c177",
 		"icon.foreground": "#908caa",
-		"input.background": "#1f1d2e",
+		"input.background": "#232034",
 		"input.border": "#6e6a8633",
 		"input.foreground": "#e0def4",
 		"input.placeholderForeground": "#908caa",

--- a/themes/rose-pine-color-theme.json
+++ b/themes/rose-pine-color-theme.json
@@ -226,7 +226,7 @@
 		"gitDecoration.submoduleResourceForeground": "#f6c177",
 		"gitDecoration.untrackedResourceForeground": "#f6c177",
 		"icon.foreground": "#908caa",
-		"input.background": "#26233a80",
+		"input.background": "#1f1d2e",
 		"input.border": "#6e6a8633",
 		"input.foreground": "#e0def4",
 		"input.placeholderForeground": "#908caa",

--- a/themes/rose-pine-dawn-color-theme.json
+++ b/themes/rose-pine-dawn-color-theme.json
@@ -226,7 +226,7 @@
 		"gitDecoration.submoduleResourceForeground": "#ea9d34",
 		"gitDecoration.untrackedResourceForeground": "#ea9d34",
 		"icon.foreground": "#797593",
-		"input.background": "#f2e9e180",
+		"input.background": "#fffaf3",
 		"input.border": "#6e6a8614",
 		"input.foreground": "#575279",
 		"input.placeholderForeground": "#797593",

--- a/themes/rose-pine-dawn-color-theme.json
+++ b/themes/rose-pine-dawn-color-theme.json
@@ -226,7 +226,7 @@
 		"gitDecoration.submoduleResourceForeground": "#ea9d34",
 		"gitDecoration.untrackedResourceForeground": "#ea9d34",
 		"icon.foreground": "#797593",
-		"input.background": "#fffaf3",
+		"input.background": "#f9f2ea",
 		"input.border": "#6e6a8614",
 		"input.foreground": "#575279",
 		"input.placeholderForeground": "#797593",

--- a/themes/rose-pine-dawn-no-italics-color-theme.json
+++ b/themes/rose-pine-dawn-no-italics-color-theme.json
@@ -226,7 +226,7 @@
 		"gitDecoration.submoduleResourceForeground": "#ea9d34",
 		"gitDecoration.untrackedResourceForeground": "#ea9d34",
 		"icon.foreground": "#797593",
-		"input.background": "#f2e9e180",
+		"input.background": "#fffaf3",
 		"input.border": "#6e6a8614",
 		"input.foreground": "#575279",
 		"input.placeholderForeground": "#797593",

--- a/themes/rose-pine-dawn-no-italics-color-theme.json
+++ b/themes/rose-pine-dawn-no-italics-color-theme.json
@@ -226,7 +226,7 @@
 		"gitDecoration.submoduleResourceForeground": "#ea9d34",
 		"gitDecoration.untrackedResourceForeground": "#ea9d34",
 		"icon.foreground": "#797593",
-		"input.background": "#fffaf3",
+		"input.background": "#f9f2ea",
 		"input.border": "#6e6a8614",
 		"input.foreground": "#575279",
 		"input.placeholderForeground": "#797593",

--- a/themes/rose-pine-moon-color-theme.json
+++ b/themes/rose-pine-moon-color-theme.json
@@ -226,7 +226,7 @@
 		"gitDecoration.submoduleResourceForeground": "#f6c177",
 		"gitDecoration.untrackedResourceForeground": "#f6c177",
 		"icon.foreground": "#908caa",
-		"input.background": "#39355280",
+		"input.background": "#2a273f",
 		"input.border": "#817c9c26",
 		"input.foreground": "#e0def4",
 		"input.placeholderForeground": "#908caa",

--- a/themes/rose-pine-moon-color-theme.json
+++ b/themes/rose-pine-moon-color-theme.json
@@ -226,7 +226,7 @@
 		"gitDecoration.submoduleResourceForeground": "#f6c177",
 		"gitDecoration.untrackedResourceForeground": "#f6c177",
 		"icon.foreground": "#908caa",
-		"input.background": "#2a273f",
+		"input.background": "#322e49",
 		"input.border": "#817c9c26",
 		"input.foreground": "#e0def4",
 		"input.placeholderForeground": "#908caa",

--- a/themes/rose-pine-moon-no-italics-color-theme.json
+++ b/themes/rose-pine-moon-no-italics-color-theme.json
@@ -226,7 +226,7 @@
 		"gitDecoration.submoduleResourceForeground": "#f6c177",
 		"gitDecoration.untrackedResourceForeground": "#f6c177",
 		"icon.foreground": "#908caa",
-		"input.background": "#39355280",
+		"input.background": "#2a273f",
 		"input.border": "#817c9c26",
 		"input.foreground": "#e0def4",
 		"input.placeholderForeground": "#908caa",

--- a/themes/rose-pine-moon-no-italics-color-theme.json
+++ b/themes/rose-pine-moon-no-italics-color-theme.json
@@ -226,7 +226,7 @@
 		"gitDecoration.submoduleResourceForeground": "#f6c177",
 		"gitDecoration.untrackedResourceForeground": "#f6c177",
 		"icon.foreground": "#908caa",
-		"input.background": "#2a273f",
+		"input.background": "#322e49",
 		"input.border": "#817c9c26",
 		"input.foreground": "#e0def4",
 		"input.placeholderForeground": "#908caa",

--- a/themes/rose-pine-no-italics-color-theme.json
+++ b/themes/rose-pine-no-italics-color-theme.json
@@ -226,7 +226,7 @@
 		"gitDecoration.submoduleResourceForeground": "#f6c177",
 		"gitDecoration.untrackedResourceForeground": "#f6c177",
 		"icon.foreground": "#908caa",
-		"input.background": "#1f1d2e",
+		"input.background": "#232034",
 		"input.border": "#6e6a8633",
 		"input.foreground": "#e0def4",
 		"input.placeholderForeground": "#908caa",

--- a/themes/rose-pine-no-italics-color-theme.json
+++ b/themes/rose-pine-no-italics-color-theme.json
@@ -226,7 +226,7 @@
 		"gitDecoration.submoduleResourceForeground": "#f6c177",
 		"gitDecoration.untrackedResourceForeground": "#f6c177",
 		"icon.foreground": "#908caa",
-		"input.background": "#26233a80",
+		"input.background": "#1f1d2e",
 		"input.border": "#6e6a8633",
 		"input.foreground": "#e0def4",
 		"input.placeholderForeground": "#908caa",


### PR DESCRIPTION
## Purpose
To prevent input field from visually separated with other input panel element. It currently has no left padding and has sharp corners due to the separation, resulting in visual inconsistencies.
## Solution
Modify the color code used for `input.background` for all six variants, and use `$surface` for `input.background` in `_pinecone-color-theme.json`.
## Comparison
before:
<img width="473" height="130" alt="image" src="https://github.com/user-attachments/assets/0824fab9-c042-4c74-a8b1-dc7794b1bd50" />

after:
<img width="474" height="142" alt="image" src="https://github.com/user-attachments/assets/60c15de9-dcd3-4989-9e45-1de5f24c288f" />