### PR TITLE
fix: update breakpoint disabled foreground colors for better visibility

### DIFF
--- a/themes/_pinecone-color-theme.json
+++ b/themes/_pinecone-color-theme.json
@@ -48,7 +48,7 @@
 		"debugExceptionWidget.background": "$surface",
 		"debugExceptionWidget.border": "$highlightMed",
 		"debugIcon.breakpointCurrentStackframeForeground": "$subtle",
-		"debugIcon.breakpointDisabledForeground": "$subtle",
+		"debugIcon.breakpointDisabledForeground": "$highlightHigh",
 		"debugIcon.breakpointForeground": "$subtle",
 		"debugIcon.breakpointStackframeForeground": "$subtle",
 		"debugIcon.breakpointUnverifiedForeground": "$subtle",

--- a/themes/rose-pine-color-theme.json
+++ b/themes/rose-pine-color-theme.json
@@ -39,7 +39,7 @@
 		"debugExceptionWidget.background": "#1f1d2e",
 		"debugExceptionWidget.border": "#6e6a8633",
 		"debugIcon.breakpointCurrentStackframeForeground": "#908caa",
-		"debugIcon.breakpointDisabledForeground": "#908caa",
+		"debugIcon.breakpointDisabledForeground": "#524f67",
 		"debugIcon.breakpointForeground": "#908caa",
 		"debugIcon.breakpointStackframeForeground": "#908caa",
 		"debugIcon.breakpointUnverifiedForeground": "#908caa",

--- a/themes/rose-pine-dawn-color-theme.json
+++ b/themes/rose-pine-dawn-color-theme.json
@@ -39,7 +39,7 @@
 		"debugExceptionWidget.background": "#fffaf3",
 		"debugExceptionWidget.border": "#6e6a8614",
 		"debugIcon.breakpointCurrentStackframeForeground": "#797593",
-		"debugIcon.breakpointDisabledForeground": "#797593",
+		"debugIcon.breakpointDisabledForeground": "#9893a5",
 		"debugIcon.breakpointForeground": "#797593",
 		"debugIcon.breakpointStackframeForeground": "#797593",
 		"debugIcon.breakpointUnverifiedForeground": "#797593",

--- a/themes/rose-pine-dawn-no-italics-color-theme.json
+++ b/themes/rose-pine-dawn-no-italics-color-theme.json
@@ -39,7 +39,7 @@
 		"debugExceptionWidget.background": "#fffaf3",
 		"debugExceptionWidget.border": "#6e6a8614",
 		"debugIcon.breakpointCurrentStackframeForeground": "#797593",
-		"debugIcon.breakpointDisabledForeground": "#797593",
+		"debugIcon.breakpointDisabledForeground": "#9893a5",
 		"debugIcon.breakpointForeground": "#797593",
 		"debugIcon.breakpointStackframeForeground": "#797593",
 		"debugIcon.breakpointUnverifiedForeground": "#797593",

--- a/themes/rose-pine-moon-color-theme.json
+++ b/themes/rose-pine-moon-color-theme.json
@@ -39,7 +39,7 @@
 		"debugExceptionWidget.background": "#2a273f",
 		"debugExceptionWidget.border": "#817c9c26",
 		"debugIcon.breakpointCurrentStackframeForeground": "#908caa",
-		"debugIcon.breakpointDisabledForeground": "#908caa",
+		"debugIcon.breakpointDisabledForeground": "#56526e",
 		"debugIcon.breakpointForeground": "#908caa",
 		"debugIcon.breakpointStackframeForeground": "#908caa",
 		"debugIcon.breakpointUnverifiedForeground": "#908caa",

--- a/themes/rose-pine-moon-no-italics-color-theme.json
+++ b/themes/rose-pine-moon-no-italics-color-theme.json
@@ -39,7 +39,7 @@
 		"debugExceptionWidget.background": "#2a273f",
 		"debugExceptionWidget.border": "#817c9c26",
 		"debugIcon.breakpointCurrentStackframeForeground": "#908caa",
-		"debugIcon.breakpointDisabledForeground": "#908caa",
+		"debugIcon.breakpointDisabledForeground": "#56526e",
 		"debugIcon.breakpointForeground": "#908caa",
 		"debugIcon.breakpointStackframeForeground": "#908caa",
 		"debugIcon.breakpointUnverifiedForeground": "#908caa",

--- a/themes/rose-pine-no-italics-color-theme.json
+++ b/themes/rose-pine-no-italics-color-theme.json
@@ -39,7 +39,7 @@
 		"debugExceptionWidget.background": "#1f1d2e",
 		"debugExceptionWidget.border": "#6e6a8633",
 		"debugIcon.breakpointCurrentStackframeForeground": "#908caa",
-		"debugIcon.breakpointDisabledForeground": "#908caa",
+		"debugIcon.breakpointDisabledForeground": "#524f67",
 		"debugIcon.breakpointForeground": "#908caa",
 		"debugIcon.breakpointStackframeForeground": "#908caa",
 		"debugIcon.breakpointUnverifiedForeground": "#908caa",


### PR DESCRIPTION
This PR fixes #115

| Theme | Before | After |
|------|--------|-------|
| Rose Pine | <img src="https://github.com/user-attachments/assets/c62810d2-37f5-49d4-8b23-b3e2385f0993" width="120"/> | <img src="https://github.com/user-attachments/assets/9e06924a-b7ef-40f3-986b-fbca199198b5" width="120"/> |
| Rose Pine Moon | <img src="https://github.com/user-attachments/assets/3626df65-1b23-4110-99fd-0fb8b062d6b8" width="120"/> | <img src="https://github.com/user-attachments/assets/3d72250a-ec0a-4eb8-9339-6a3426eabf00" width="120"/> |
| Rose Pine Dawn | <img src="https://github.com/user-attachments/assets/fdccaf0d-0680-4e11-a19f-fac1d9f37a41" width="120"/> | <img src="https://github.com/user-attachments/assets/b87bded4-b345-4d23-a6a9-b185161248d8" width="120"/> |
